### PR TITLE
Fix Windows builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "main.js",
   "scripts": {
     "start": "electron .",
-    "dist": "build"
+    "dist": "build",
+    "postinstall": "npmpd --no-save"
   },
   "repository": {
     "type": "git",
@@ -32,11 +33,20 @@
   "homepage": "https://github.com/nirewen/discord-netflix#readme",
   "dependencies": {
     "discord-rpc": "^3.0.0-beta.8",
-    "electron-widevinecdm": "^5.0.2",
     "moment": "^2.22.1"
   },
   "devDependencies": {
     "electron": "^1.8.2-beta.5",
-    "electron-builder": "^19.55.3"
+    "electron-builder": "^19.55.3",
+    "npm-platform-dependencies": "^0.1.0"
+  },
+  "darwinDependencies": {
+    "electron-widevinecdm": "^7.0.0"
+  },
+  "linuxDependencies": {
+    "electron-widevinecdm": "^7.0.0"
+  },
+  "win32Dependencies": {
+    "electron-widevinecdm": "^5.0.2"
   }
 }


### PR DESCRIPTION
electron-widevinecdm discontinued windows support past version 5.0.2 and the update #8 broke Windows builds by changing the version to ^7.0.0 which only has support for darwin and linux. This fix adds a package which is used in "postinstall" to determine what version of electron-widevinecdm to install and use based on the OS building the program.