### PR TITLE
RPC fix, App Closure fix, and avatar changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/node_modules
+/.vscode

--- a/main.js
+++ b/main.js
@@ -90,7 +90,7 @@ async function checkNetflix() {
 				
 				smallImageText = "Playing";
                 endTime = now.add(remaining).unix();
-            } else (videoPaused) { smallImageText = "Paused" }
+            } else { smallImageText = "Paused"; }
         }
         
         rpc.setActivity({
@@ -120,8 +120,6 @@ app.on('ready', () => {
     login();
 });
 
-app.on('window-all-closed', app.quit);
-app.on('before-quit', () => {
-    mainWindow.removeAllListeners('close');
-    mainWindow.close();
+app.on('window-all-closed', () => {
+    app.quit();
 });

--- a/main.js
+++ b/main.js
@@ -3,6 +3,7 @@ const {Client} 			   = require('discord-rpc');
 const widevine             = require('electron-widevinecdm');
 const moment               = require('moment');
 const rpc                  = new Client({transport: 'ipc'});
+const crypto               = require('crypto');
 
 widevine.load(app);
 
@@ -43,7 +44,7 @@ let appID = '387083698358714368',
         if (type == 'watch' && document.querySelector(".ellipsize-text")) {
             let name = document.querySelector('.ellipsize-text'),
                 span = document.querySelector('.ellipsize-text').querySelectorAll('span'),
-                video = document.getElementById(id).getElementsByTagName('video')[0];
+                video = document.querySelector('.VideoContainer').getElementsByTagName('video')[0];
             return {
                 name             : name.querySelector('h4') ? name.querySelector('h4').innerHTML : name.innerHTML,
                 title            : span.length ? span[1].innerHTML : undefined,
@@ -80,7 +81,7 @@ async function checkNetflix() {
             curr = parseInt(new Date().getTime().toString().slice(0, 10));
         let endTime = null;
          
-        if (avatar) smallImageKey = avatar;
+        if (avatar) smallImageKey = crypto.createHash('md5').update(avatar).digest('hex');
 
 		smallImageText = "Idle"
         if (videoDuration && videoCurrentTime) {


### PR DESCRIPTION
### RPC
There seemed to be a bug in the RPC now that didn't detect the video you were watching so that was fixed and now should detect it again.

### App Closure
There was a long standing bug that I meant to push a long time ago that the app didn't close itself properly and hung around in the processes forever which is a resource hog and shouldn't be doing that. I'd imagine the intention was to close the app properly on exiting.

### Avatar Changes
So in relation to #23 I did something for you @nirewen which was moved the avatar check to an MD5 hash of the avatar which also fixes the problem mentioned in #24 which the too large of a key as 32 characters is the max length Discord supports and an MD5 hash is 32 characters. You will need to go through each avatar and update your Discord application manually to be the MD5 hashes of the SHA1 hash Netflix uses which is too long at 40 characters.

#### Side Note
I added a .gitignore to the repo to make life easier so you don't have to delete node_modules or other stuff just to push