### PR TITLE
Changed innerHTML to textContent

### DIFF
--- a/src/util/scripts/infos.js
+++ b/src/util/scripts/infos.js
@@ -44,7 +44,7 @@ module.exports = function () {
         let interactive = false
         // TODO: Better interactive video check. Severe problems are caused in the solutions currently found
 
-        name = name.querySelector('h4') ? name.querySelector('h4').textContent : name.innerText
+        name = name.querySelector('h4') ? name.querySelector('h4').innerText : name.innerText
 
         return { name, title, episode, duration, currentTime, paused, interactive, avatar, userName }
     }

--- a/src/util/scripts/infos.js
+++ b/src/util/scripts/infos.js
@@ -44,7 +44,7 @@ module.exports = function () {
         let interactive = false
         // TODO: Better interactive video check. Severe problems are caused in the solutions currently found
 
-        name = name.querySelector('h4') ? name.querySelector('h4').innerHTML : name.innerText
+        name = name.querySelector('h4') ? name.querySelector('h4').textContent : name.innerText
 
         return { name, title, episode, duration, currentTime, paused, interactive, avatar, userName }
     }


### PR DESCRIPTION
```js
document.querySelector('.ellipsize-text').querySelector('h4').innerHTML
```
This returns the name of movie with HTML entity. 

I was watching **Love, Death & Robots** and it was showing up as **Watching Love, Death _\&amp;_ Robots**.

e.g. **&** turns into **\&amp;**