### PR TITLE
Fix invalid package name, don't try to publish on build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
-  "name": "Netflix",
+  "name": "netflix",
   "version": "2.2.1",
   "description": "A Netflix wrapper with Discord Rich Presence",
   "main": "src/index.js",
   "scripts": {
     "start": "electron .",
-    "dist:mac": "build -m --publish always",
-    "dist:linux": "build -l --publish always",
-    "dist:win": "build -w --publish always"
+    "dist:mac": "build -m",
+    "dist:linux": "build -l",
+    "dist:win": "build -w"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The current package name violates the requirement that it needs to be lowercase. Additionally, don't try to publish after building. When people try to build this for themselves, it will try to publish immediately after and then throw an error for not providing a GitHub token. This would definitely confuse people, like me, trying to figure out why it needed a GitHub token, then failed even when providing one.